### PR TITLE
Add read_upto and rename read to read_exactly

### DIFF
--- a/eunix.mli
+++ b/eunix.mli
@@ -30,7 +30,18 @@ val alloc : unit -> Uring.Region.chunk
 val free : Uring.Region.chunk -> unit
 
 (** {1 File manipulation functions} *)
-val read : ?file_offset:int -> Unix.file_descr -> Uring.Region.chunk -> int -> unit
+
+val read_upto : ?file_offset:int -> Unix.file_descr -> Uring.Region.chunk -> int -> int
+(** [read_upto fd chunk len] reads at most [len] bytes from [fd],
+    returning as soon as some data is available.
+    @param file_offset Read from the given position in [fd] (default: 0).
+    @raise End_of_file Raised if all data has already been read. *)
+
+val read_exactly : ?file_offset:int -> Unix.file_descr -> Uring.Region.chunk -> int -> unit
+(** [read_exactly fd chunk len] reads exactly [len] bytes from [fd],
+    performing multiple read operations if necessary.
+    @param file_offset Read from the given position in [fd] (default: 0).
+    @raise End_of_file Raised if the stream ends before [len] bytes have been read. *)
 
 val write : ?file_offset:int -> Unix.file_descr -> Uring.Region.chunk -> int -> unit
 

--- a/tests/eurcp_lib.ml
+++ b/tests/eurcp_lib.ml
@@ -5,7 +5,7 @@ module U = Eunix
 let read_then_write_chunk infd outfd file_offset len =
   let buf = U.alloc () in
   Logs.debug (fun l -> l "r/w start %d (%d)" file_offset len);
-  U.read ~file_offset infd buf len;
+  U.read_exactly ~file_offset infd buf len;
   U.write ~file_offset outfd buf len;
   Logs.debug (fun l -> l "r/w done  %d (%d)" file_offset len);
   U.free buf


### PR DESCRIPTION
`read` would keep waiting until it had filled the buffer. When reading e.g. an HTTP request from a network connection, you don't know how long it will be and should just process whatever data arrives.