### PR TITLE
Use separate type for exiting the scheduler

### DIFF
--- a/zzz.ml
+++ b/zzz.ml
@@ -26,7 +26,7 @@
 type sleep = {
   time : float;
   mutable canceled : bool;
-  thread : (unit, unit) continuation option;
+  thread : (unit, [`Exit_scheduler]) continuation option;
 }
 
 module SleepQueue =


### PR DESCRIPTION
Before, the continuations all returned `unit`. This makes it easy to get confused about what it means (as in #1 and #3). Using a distinct type for this should prevent such errors in future.

The error in #1 now results in:

    Error: This expression has type effect but an expression was expected of type
             [ `Exit_scheduler ]

The error in #3 now results in:

    Error: This expression has type [ `Exit_scheduler ]
           but an expression was expected of type unit
           because it is in the left-hand side of a sequence