### PR TITLE
Return a promise from fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	dune build @runtest @install

--- a/eunix.mli
+++ b/eunix.mli
@@ -16,8 +16,37 @@
 
 type t
 
+module Promise : sig
+  type 'a t
+  (** An ['a t] is a promise for a value of type ['a]. *)
+
+  type 'a u
+  (** An ['a u] is a resolver for a promise of type ['a]. *)
+
+  val create : unit -> 'a t * 'a u
+  (** [create ()] is a fresh promise/resolver pair.
+      The promise is initially unresolved. *)
+
+  val await : 'a t -> 'a
+  (** [await t] blocks until [t] is resolved.
+      If [t] is already resolved then this returns immediately.
+      If [t] is broken, it raises the exception. *)
+
+  val fulfill : 'a u -> 'a -> unit
+  (** [fulfill u v] successfully resolves [u]'s promise with the value [v].
+      Any threads waiting for the result will be added to the run queue. *)
+
+  val break : 'a u -> exn -> unit
+  (** [break u ex] resolves [u]'s promise with the exception [ex].
+      Any threads waiting for the result will be added to the run queue. *)
+
+  val state : 'a t -> [ `Fulfilled of 'a | `Broken of exn | `Unresolved ]
+end
+
 (** {1 Fibre functions} *)
-val fork : (unit -> unit) -> unit
+
+val fork : (unit -> 'a) -> 'a Promise.t
+(** [fork fn] starts running [fn ()] and returns a promise for its result. *)
 
 val yield : unit -> unit
 

--- a/tests/dune
+++ b/tests/dune
@@ -12,3 +12,8 @@
  (name basic_eunix)
  (modules basic_eunix)
  (libraries logs.fmt fmt.tty eurcp_lib))
+
+(test
+ (name test)
+ (modules test)
+ (libraries alcotest eunix uring))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,0 +1,51 @@
+open Eunix
+
+let () =
+  Logs.(set_level ~all:true (Some Debug));
+  Logs.set_reporter @@ Logs.format_reporter ();
+  Printexc.record_backtrace true
+
+let state t =
+  Alcotest.of_pp
+    (fun f -> function
+       | `Unresolved -> Fmt.string f "unresolved"
+       | `Broken (Failure msg) -> Fmt.pf f "broken:%s" msg
+       | `Broken ex -> Fmt.pf f "broken:%a" Fmt.exn ex
+       | `Fulfilled x -> Fmt.pf f "fulfilled:%a" (Alcotest.pp t) x
+    )
+
+let test_promise () =
+  Eunix.run @@ fun () ->
+  let p, r = Promise.create () in
+  Alcotest.(check (state string)) "Initially unresolved" (Promise.state p) `Unresolved;
+  let thread = Eunix.fork (fun () -> Promise.await p) in
+  Promise.fulfill r "ok";
+  Alcotest.(check (state string)) "Resolved OK" (Promise.state p) (`Fulfilled "ok");
+  Alcotest.(check (state string)) "Thread unresolved" (Promise.state thread) `Unresolved;
+  yield ();
+  Alcotest.(check (state string)) "Thread resolved" (Promise.state thread) @@ `Fulfilled "ok";
+  let result = Promise.await thread in
+  Alcotest.(check string) "Await result" result "ok"
+
+let test_promise_exn () =
+  Eunix.run @@ fun () ->
+  let p, r = Promise.create () in
+  Alcotest.(check (state reject)) "Initially unresolved" (Promise.state p) `Unresolved;
+  let thread = Eunix.fork (fun () -> Promise.await p) in
+  Promise.break r (Failure "test");
+  Alcotest.(check (state reject)) "Broken" (Promise.state p) @@ `Broken (Failure "test");
+  Alcotest.(check (state reject)) "Thread unresolved" (Promise.state thread) `Unresolved;
+  yield ();
+  Alcotest.(check (state reject)) "Thread broken" (Promise.state thread) @@ `Broken (Failure "test");
+  match Promise.await thread with
+  | `Cant_happen -> assert false
+  | exception (Failure msg) -> Alcotest.(check string) "Await result" msg "test"
+
+let () =
+  let open Alcotest in
+  run "eioio" [
+    "simple", [
+      test_case "promise"      `Quick test_promise;
+      test_case "promise_exn"  `Quick test_promise_exn;
+    ];
+  ]


### PR DESCRIPTION
`fork f` now returns a promise for the result of `f`. This allows forking multiple threads and then collecting the results later.