### PR TITLE
Add Fibreslib.Semaphore

### DIFF
--- a/fibreslib/fibreslib.ml
+++ b/fibreslib/fibreslib.ml
@@ -1,9 +1,10 @@
 module Promise = Promise
 module Fibre = Fibre
+module Semaphore = Semaphore
 
 module Fibre_impl = struct
   module Effects = struct
-    effect Await = Promise.Await
+    effect Await = Waiters.Await
     effect Fork = Fibre.Fork
     effect Fork_detach = Fibre.Fork_detach
     effect Yield = Fibre.Yield

--- a/fibreslib/promise.ml
+++ b/fibreslib/promise.ml
@@ -12,25 +12,23 @@ type 'a u = 'a t
 
 type 'a waiters = 'a Waiters.t
 
-effect Await : Ctf.id * 'a Waiters.t -> 'a
-
 let create_with_id id =
   let t = { id; state = Unresolved (Waiters.create ()) } in
   t, t
 
 let create ?label () =
   let id = Ctf.mint_id () in
-  Ctf.note_created ?label id Ctf.Task;
+  Ctf.note_created ?label id Ctf.Promise;
   create_with_id id
 
 let fulfilled x =
   let id = Ctf.mint_id () in
-  Ctf.note_created id Ctf.Task;
+  Ctf.note_created id Ctf.Promise;
   { id; state = Fulfilled x }
 
 let broken ex =
   let id = Ctf.mint_id () in
-  Ctf.note_created id Ctf.Task;
+  Ctf.note_created id Ctf.Promise;
   { id; state = Broken ex }
 
 let await t =
@@ -43,7 +41,7 @@ let await t =
     raise ex
   | Unresolved q ->
     Ctf.note_try_read t.id;
-    perform (Await (t.id, q))
+    Waiters.await q t.id
 
 let await_result t =
   match await t with

--- a/fibreslib/semaphore.ml
+++ b/fibreslib/semaphore.ml
@@ -1,0 +1,45 @@
+type state =
+  | Free of int
+  | Waiting of unit Waiters.t
+
+type t = {
+  id : Ctf.id;
+  mutable state : state;
+}
+
+let make n =
+  if n < 0 then raise (Invalid_argument "n < 0");
+  let id = Ctf.mint_id () in
+  Ctf.note_created id Ctf.Semaphore;
+  {
+    id;
+    state = Free n;
+  }
+
+let release t =
+  Ctf.note_signal t.id;
+  match t.state with
+  | Free x when x = max_int -> raise (Sys_error "semaphore would overflow max_int!")
+  | Free x -> t.state <- Free (succ x)
+  | Waiting q ->
+    match Waiters.wake_one q (Ok ()) with
+    | `Ok -> ()
+    | `Queue_empty ->
+      t.state <- Free 1
+
+let rec acquire t =
+  match t.state with
+  | Waiting q ->
+    Ctf.note_try_read t.id;
+    Waiters.await q t.id
+  | Free 0 ->
+    t.state <- Waiting (Waiters.create ());
+    acquire t
+  | Free n ->
+    Ctf.note_read t.id;
+    t.state <- Free (pred n)
+
+let get_value t =
+  match t.state with
+  | Free n -> n
+  | Waiting _ -> 0

--- a/fibreslib/waiters.ml
+++ b/fibreslib/waiters.ml
@@ -1,5 +1,7 @@
 type 'a t = (('a, exn) result -> unit) Queue.t
 
+effect Await : Ctf.id * 'a t -> 'a
+
 let create = Queue.create
 
 let add_waiter t cb =
@@ -7,3 +9,11 @@ let add_waiter t cb =
 
 let wake_all t v =
   Queue.iter (fun f -> f v) t
+
+let wake_one t v =
+  match Queue.take_opt t with
+  | None -> `Queue_empty
+  | Some f -> f v; `Ok
+
+let await t id =
+  perform (Await (id, t))

--- a/fibreslib/waiters.mli
+++ b/fibreslib/waiters.mli
@@ -1,8 +1,9 @@
 type 'a t
-(** A queue of callbacks waiting for a value of type ['a]. *)
 
 val create : unit -> 'a t
-
 val add_waiter : 'a t -> (('a, exn) result -> unit) -> unit
-
 val wake_all : 'a t -> ('a, exn) result -> unit
+val wake_one : 'a t -> ('a, exn) result -> [`Ok | `Queue_empty]
+val await : 'a t -> Ctf.id -> 'a
+
+effect Await : Ctf.id * 'a t -> 'a

--- a/lib_ctf/ctf.mli
+++ b/lib_ctf/ctf.mli
@@ -43,6 +43,8 @@ type event =
   | On_any
   | Ignore_result
   | Async
+  | Promise
+  | Semaphore
 (** Types of threads or other recorded objects. *)
 
 val mint_id : unit -> id
@@ -75,8 +77,9 @@ val note_resolved : id -> ex:exn option -> unit
 (** [note_resolved id ~ex] records that [id] is now resolved.
     If [ex = None] then [id] was successful, otherwise it failed with exception [ex]. *)
 
-val note_signal : src:id -> dst:id -> unit
-(** [note_signal ~src dst] records that [src] signalled [dst]. *)
+val note_signal : ?src:id -> id -> unit
+(** [note_signal ~src dst] records that [dst] was signalled.
+    @param src The thread sending the signal (default is the current thread). *)
 
 (** {2 Controlling tracing} *)
 


### PR DESCRIPTION
Useful for e.g. rate-limiting.

The API is based on OCaml's `Semaphore.Counting`. A couple of differences are:

1. `release` always releases the fibre that has been waiting the longest.
2. `get_value` is not racy.